### PR TITLE
feat: run callback when an event is emitted

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,7 +1,12 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
-import '@kuscamara/sample-lit-element'
+import '@kuscamara/sample-lit-element';
+import 'in-app-component';
+
+const refObject = {
+  foo: 'bar'
+};
 
 export default Controller.extend({
   vip: true,
@@ -23,6 +28,8 @@ export default Controller.extend({
   avatarImage: 'random-3.png',
 
   avatarSize: 100,
+
+  dummyObject: refObject,
 
   avatar: computed('avatarSrc', 'avatarSize', 'avatarImage', {
     get(key) {
@@ -51,6 +58,11 @@ export default Controller.extend({
       this.set('avatarSize', 150);
 
       toast.info(`Detail: ${detail}`, `Event: ${type}`, options);
+    },
+
+    anotherAction(event) {
+      refObject.foo = refObject.foo + '-aa';
+      console.log(event);
     }
   }
 });

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -15,6 +15,12 @@
         cats={{catNames}}>
       </sample-lit-element>
     </ElementEventListener>
+
+    <in-app-component
+      name="Kus"
+      someProp={{dummyObject}}
+      onNameChanged={{action 'anotherAction'}}>
+    </in-app-component>
   </div>
 
   <div class="form">

--- a/components/in-app-component/index.js
+++ b/components/in-app-component/index.js
@@ -1,0 +1,73 @@
+import { LitElement, html } from 'lit-element';
+
+function camelCase(string, wordSeparators = []) {
+  const separators = Array.isArray(wordSeparators) ? wordSeparators : [wordSeparators];
+  const regexp = new RegExp(`[${separators.join('')}].`, 'g');
+
+  return string.replace(regexp, (match) => match.charAt(1).toUpperCase());
+}
+
+function dashToCamel(string) {
+  return camelCase(string, '-');
+}
+
+function capitalize(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+function runCallback(type, event) {
+  const methodName = `on${capitalize(dashToCamel(type))}`;
+
+  if (typeof this[methodName] === 'function') {
+    this[methodName](event);
+  }
+}
+
+class InAppComponent extends LitElement {
+  static get properties() {
+    return {
+      name: { type: String },
+      someProp: { type: Object }
+    };
+  }
+
+  constructor() {
+    super();
+
+    this.onNameChanged = () => {};
+    this.fireEventWithCallback = (type, params) => {
+      const event = new CustomEvent(type, params);
+      this.dispatchEvent(event);
+      runCallback.call(this, type, event);
+    }
+  }
+
+  updated(changedProps) {
+    if (changedProps.has('name') && changedProps.get('name') !== undefined) {
+      this._onNameChanged();
+
+      // double curly bindings in Ember sets properties (not attributes) so references are keept (no serialization)
+      console.log('someProp', this.someProp);
+    }
+  }
+
+  _onNameChanged() {
+    this.fireEventWithCallback('name-changed', {
+      composed: true,
+      detail: this.name
+    });
+  }
+
+  _onButtonClick() {
+    this.name += '-a';
+  }
+
+  render() {
+    return html`
+      <p>Hola ${this.name}</p>
+      <button @click="${this._onButtonClick}">Change name</button>
+    `;
+  }
+}
+
+customElements.define('in-app-component', InAppComponent);

--- a/components/in-app-component/package.json
+++ b/components/in-app-component/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "in-app-component"
+}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const funnel = require('broccoli-funnel');
 
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
@@ -20,5 +21,7 @@ module.exports = function(defaults) {
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
 
-  return app.toTree();
+  const components = funnel('components', { include: ['**/*.js'] });
+
+  return app.toTree(components);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -974,6 +974,29 @@
         "ember-cli-babel": "^6.6.0",
         "jquery": "^3.3.1",
         "resolve": "^1.7.1"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        }
       }
     },
     "@ember/optional-features": {
@@ -1043,6 +1066,29 @@
         "ember-assign-polyfill": "~2.4.0",
         "ember-cli-babel": "^6.12.0",
         "ember-cli-htmlbars-inline-precompile": "^1.0.0"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        }
       }
     },
     "@glimmer/compiler": {
@@ -1184,11 +1230,21 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+    },
     "@types/node": {
       "version": "9.6.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.41.tgz",
       "integrity": "sha512-sPZWEbFMz6qAy9SLY7jh5cgepmsiwqUUHjvEm8lpU6kug2hmmcyuTnwhoGw/GWpI5Npue4EqvsiQQI0eWjW/ZA==",
       "dev": true
+    },
+    "@types/symlink-or-copy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz",
+      "integrity": "sha512-Lja2xYuuf2B3knEsga8ShbOdsfNOtzT73GyJmZyY7eGl2+ajOqrs8yM5ze0fsSoYwvA6bw7/Qr7OZ7PEEmYwWg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
@@ -1598,8 +1654,7 @@
     "array-equal": {
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-      "dev": true
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -2493,8 +2548,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -2608,8 +2662,7 @@
     "blank-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.2.tgz",
-      "integrity": "sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk=",
-      "dev": true
+      "integrity": "sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk="
     },
     "blob": {
       "version": "0.0.5",
@@ -2711,7 +2764,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2834,6 +2886,37 @@
         "workerpool": "^2.3.0"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^1.0.1"
+          }
+        },
         "rsvp": {
           "version": "4.8.4",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
@@ -3002,24 +3085,99 @@
       }
     },
     "broccoli-funnel": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
-      "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
-      "dev": true,
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.3.tgz",
+      "integrity": "sha512-LPzZ91BwStoHZXdXHQAJeYORl189OrRKM5NdIi86SDU9wZ4s/3lV1PRFOiobDT/jKM10voM7CDzfvicHbCYxAQ==",
       "requires": {
         "array-equal": "^1.0.0",
         "blank-object": "^1.0.1",
-        "broccoli-plugin": "^1.3.0",
-        "debug": "^2.2.0",
+        "broccoli-plugin": "^4.0.1",
+        "debug": "^4.1.1",
         "fast-ordered-set": "^1.0.0",
-        "fs-tree-diff": "^0.5.3",
+        "fs-tree-diff": "^2.0.1",
         "heimdalljs": "^0.2.0",
         "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
         "path-posix": "^1.0.0",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0",
-        "walk-sync": "^0.3.1"
+        "walk-sync": "^2.0.2"
+      },
+      "dependencies": {
+        "broccoli-plugin": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz",
+          "integrity": "sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==",
+          "requires": {
+            "broccoli-node-api": "^1.6.0",
+            "broccoli-output-wrapper": "^3.2.1",
+            "fs-merger": "^3.1.0",
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^3.0.0",
+            "symlink-or-copy": "^1.3.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ensure-posix-path": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz",
+          "integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw=="
+        },
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "matcher-collection": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
+          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "minimatch": "^3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "symlink-or-copy": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.3.1.tgz",
+          "integrity": "sha512-0K91MEXFpBUaywiwSSkmKjnGcasG/rVBXFLJz5DrgGabpYD6N+3yZrfD6uUIfpuTu65DZLHi7N8CizHc07BPZA=="
+        },
+        "walk-sync": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^2.0.0",
+            "minimatch": "^3.0.4"
+          }
+        }
       }
     },
     "broccoli-funnel-reducer": {
@@ -3069,13 +3227,55 @@
       }
     },
     "broccoli-merge-trees": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
-      "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
+      "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
       "dev": true,
       "requires": {
-        "broccoli-plugin": "^1.3.0",
-        "merge-trees": "^1.0.1"
+        "broccoli-plugin": "^4.0.2",
+        "merge-trees": "^2.0.0"
+      },
+      "dependencies": {
+        "broccoli-plugin": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz",
+          "integrity": "sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.6.0",
+            "broccoli-output-wrapper": "^3.2.1",
+            "fs-merger": "^3.1.0",
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^3.0.0",
+            "symlink-or-copy": "^1.3.0"
+          }
+        },
+        "merge-trees": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
+          "integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
+          "dev": true,
+          "requires": {
+            "fs-updater": "^1.0.4",
+            "heimdalljs": "^0.2.5"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "symlink-or-copy": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.3.1.tgz",
+          "integrity": "sha512-0K91MEXFpBUaywiwSSkmKjnGcasG/rVBXFLJz5DrgGabpYD6N+3yZrfD6uUIfpuTu65DZLHi7N8CizHc07BPZA==",
+          "dev": true
+        }
       }
     },
     "broccoli-middleware": {
@@ -3111,11 +3311,43 @@
         "walk-sync": "^0.3.2"
       }
     },
+    "broccoli-node-api": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/broccoli-node-api/-/broccoli-node-api-1.7.0.tgz",
+      "integrity": "sha512-QIqLSVJWJUVOhclmkmypJJH9u9s/aWH4+FH6Q6Ju5l+Io4dtwqdPUNmDfw40o6sxhbZHhqGujDJuHTML1wG8Yw=="
+    },
     "broccoli-node-info": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/broccoli-node-info/-/broccoli-node-info-1.1.0.tgz",
       "integrity": "sha1-OqLjHgflvbUW3SUhT3xFuhxFlBI=",
       "dev": true
+    },
+    "broccoli-output-wrapper": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-3.2.3.tgz",
+      "integrity": "sha512-vzbm4j59Wr5vr/O50LD43Np1jbLBWJ/vhppzL/UXWf39xac9grJtrlx9SSy+pDRNT2LGBHNIGPOhdqwp94q2Pg==",
+      "requires": {
+        "fs-extra": "^8.1.0",
+        "heimdalljs-logger": "^0.1.10",
+        "symlink-or-copy": "^1.2.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+        }
+      }
     },
     "broccoli-persistent-filter": {
       "version": "1.4.6",
@@ -3287,6 +3519,44 @@
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
         },
         "broccoli-merge-trees": {
@@ -4042,8 +4312,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -4522,7 +4791,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -4973,6 +5241,27 @@
             "color-convert": "^1.9.0"
           }
         },
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
         "broccoli-merge-trees": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
@@ -5050,6 +5339,29 @@
         "clone": "^2.0.0",
         "ember-cli-version-checker": "^2.1.2",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        }
       }
     },
     "ember-cli-broccoli-sane-watcher": {
@@ -5609,6 +5921,38 @@
             "color-convert": "^1.9.0"
           }
         },
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "heimdalljs": {
+              "version": "0.2.6",
+              "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.6.tgz",
+              "integrity": "sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==",
+              "dev": true,
+              "requires": {
+                "rsvp": "~3.2.1"
+              }
+            }
+          }
+        },
         "broccoli-merge-trees": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
@@ -5775,6 +6119,39 @@
         "ember-cli-babel": "^6.8.2",
         "ember-cli-test-loader": "^2.2.0",
         "qunit": "~2.6.0"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^1.0.1"
+          }
+        }
       }
     },
     "ember-resolver": {
@@ -5799,6 +6176,27 @@
           "dev": true,
           "requires": {
             "semver": "^5.3.0"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           }
         },
         "broccoli-merge-trees": {
@@ -5876,6 +6274,27 @@
             "json-stable-stringify": "^1.0.1",
             "rsvp": "^4.8.3",
             "workerpool": "^2.3.1"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           }
         },
         "broccoli-merge-trees": {
@@ -5972,6 +6391,29 @@
             "json-stable-stringify": "^1.0.1",
             "rsvp": "^4.8.3",
             "workerpool": "^2.3.1"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            }
           }
         },
         "broccoli-merge-trees": {
@@ -6006,6 +6448,29 @@
             "ember-cli-version-checker": "^2.1.2",
             "ensure-posix-path": "^1.0.2",
             "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            }
           }
         },
         "ember-sinon": {
@@ -6057,6 +6522,27 @@
                     "merge-trees": "^1.0.1"
                   }
                 }
+              }
+            },
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "dev": true,
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
               }
             },
             "ember-cli-babel": {
@@ -6177,6 +6663,37 @@
             "color-convert": "^1.9.0"
           }
         },
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^1.0.1"
+          }
+        },
         "chalk": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -6259,6 +6776,39 @@
         "broccoli-funnel": "^2.0.1",
         "broccoli-merge-trees": "^2.0.0",
         "ember-cli-babel": "^6.11.0"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^1.0.1"
+          }
+        }
       }
     },
     "ember-welcome-page": {
@@ -7135,7 +7685,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
       "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
-      "dev": true,
       "requires": {
         "blank-object": "^1.0.1"
       }
@@ -7612,6 +8161,86 @@
         "universalify": "^0.1.0"
       }
     },
+    "fs-merger": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fs-merger/-/fs-merger-3.1.0.tgz",
+      "integrity": "sha512-RZ9JtqugaE8Rkt7idO5NSwcxEGSDZpLmVFjtVQUm3f+bWun7JAU6fKyU6ZJUeUnKdJwGx8uaro+K4QQfOR7vpA==",
+      "requires": {
+        "broccoli-node-api": "^1.7.0",
+        "broccoli-node-info": "^2.1.0",
+        "fs-extra": "^8.0.1",
+        "fs-tree-diff": "^2.0.1",
+        "rimraf": "^2.6.3",
+        "walk-sync": "^2.0.2"
+      },
+      "dependencies": {
+        "broccoli-node-info": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/broccoli-node-info/-/broccoli-node-info-2.1.0.tgz",
+          "integrity": "sha512-l6qDuboJThHfRVVWQVaTs++bFdrFTP0gJXgsWenczc1PavRVUmL1Eyb2swTAXXMpDOnr2zhNOBLx4w9AxkqbPQ=="
+        },
+        "ensure-posix-path": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz",
+          "integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw=="
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+        },
+        "matcher-collection": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
+          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "minimatch": "^3.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "walk-sync": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^2.0.0",
+            "minimatch": "^3.0.4"
+          }
+        }
+      }
+    },
     "fs-tree-diff": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
@@ -7652,8 +8281,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.4",
@@ -8307,7 +8935,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -8417,8 +9044,7 @@
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "dev": true
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -8579,7 +9205,6 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.6.tgz",
       "integrity": "sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==",
-      "dev": true,
       "requires": {
         "rsvp": "~3.2.1"
       },
@@ -8587,8 +9212,7 @@
         "rsvp": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
-          "dev": true
+          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo="
         }
       }
     },
@@ -8612,7 +9236,6 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.10.tgz",
       "integrity": "sha512-pO++cJbhIufVI/fmB/u2Yty3KJD0TqNPecehFae0/eps0hkZ3b4Zc/PezUMOpYuHFQbA7FxHZxa305EhmjLj4g==",
-      "dev": true,
       "requires": {
         "debug": "^2.2.0",
         "heimdalljs": "^0.2.6"
@@ -8730,6 +9353,10 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "in-app-component": {
+      "version": "file:components/in-app-component",
+      "dev": true
+    },
     "indent-string": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
@@ -8755,7 +9382,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -8764,8 +9390,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -9388,7 +10013,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -9448,6 +10072,21 @@
       "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
+      }
+    },
+    "lit-element": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.3.1.tgz",
+      "integrity": "sha512-tOcUAmeO3BzwiQ7FGWdsshNvC0HVHcTFYw/TLIImmKwXYoV0E7zCBASa8IJ7DiP4cen/Yoj454gS0qqTnIGsFA==",
+      "requires": {
+        "lit-html": "^1.1.1"
+      },
+      "dependencies": {
+        "lit-html": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.2.1.tgz",
+          "integrity": "sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ=="
+        }
       }
     },
     "lit-html": {
@@ -10428,7 +11067,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -10500,8 +11138,7 @@
     "mktemp": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
-      "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws=",
-      "dev": true
+      "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
     },
     "morgan": {
       "version": "1.9.1",
@@ -10539,8 +11176,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mustache": {
       "version": "3.0.1",
@@ -10843,8 +11479,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-component": {
       "version": "0.0.3",
@@ -10952,7 +11587,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -11291,8 +11925,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -11315,8 +11948,7 @@
     "path-posix": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
-      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8=",
-      "dev": true
+      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -11547,7 +12179,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
-      "dev": true,
       "requires": {
         "rsvp": "^3.0.14"
       }
@@ -11660,7 +12291,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.8.tgz",
       "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
-      "dev": true,
       "requires": {
         "mktemp": "~0.4.0",
         "rimraf": "^2.5.4",
@@ -11751,6 +12381,27 @@
         "broccoli-merge-trees": "^3.0.1"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
         "broccoli-merge-trees": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
@@ -12176,7 +12827,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
       "requires": {
         "glob": "^7.0.5"
       }
@@ -12314,8 +12964,7 @@
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-      "dev": true
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
     },
     "run-async": {
       "version": "2.3.0",
@@ -13040,8 +13689,7 @@
     "sprintf-js": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "dev": true
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "sri-toolbox": {
       "version": "0.2.0",
@@ -13284,8 +13932,7 @@
     "symlink-or-copy": {
       "version": "1.2.0",
       "resolved": "http://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz",
-      "integrity": "sha512-W31+GLiBmU/ZR02Ii0mVZICuNEN9daZ63xZMPDsYgPgNjMtg+atqLEGI7PPI936jYSQZxoLb/63xos8Adrx4Eg==",
-      "dev": true
+      "integrity": "sha512-W31+GLiBmU/ZR02Ii0mVZICuNEN9daZ63xZMPDsYgPgNjMtg+atqLEGI7PPI936jYSQZxoLb/63xos8Adrx4Eg=="
     },
     "table": {
       "version": "4.0.2",
@@ -13830,7 +14477,6 @@
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
       "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "^1.0.3",
         "util-deprecate": "^1.0.2"
@@ -13929,8 +14575,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -14070,8 +14715,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -14369,8 +15013,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@ember/jquery": "^0.5.2",
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
+    "broccoli-merge-trees": "^4.2.0",
     "ember-ajax": "^3.1.0",
     "ember-auto-import": "^1.2.19",
     "ember-cli": "~3.5.0",
@@ -47,6 +48,7 @@
     "ember-toastr": "^1.7.2",
     "ember-welcome-page": "^3.2.0",
     "eslint-plugin-ember": "^5.2.0",
+    "in-app-component": "file:./components/in-app-component",
     "loader.js": "^4.7.0",
     "qunit-dom": "^0.8.0",
     "toastr": "^2.1.4"
@@ -55,6 +57,8 @@
     "node": "6.* || 8.* || >= 10.*"
   },
   "dependencies": {
-    "@kuscamara/sample-lit-element": "^1.0.7"
+    "@kuscamara/sample-lit-element": "^1.0.7",
+    "broccoli-funnel": "^3.0.3",
+    "lit-element": "^2.3.1"
   }
 }


### PR DESCRIPTION
This allows to bind actions directly to a custom element in Ember templates without the need to add event listeners.

Example:

```hbs
<my-component onSomeEvent={{action 'emberAction'}}></my-component>
```

There is also an example of how binding works when using double curly brackets in Ember templates. `<my-component someProp={{emberProp}}></my-component>` is a property binding, so no attribute deserialization happens.
